### PR TITLE
Correct 'square' typo in level 4

### DIFF
--- a/src/js/puzzles/level4.js
+++ b/src/js/puzzles/level4.js
@@ -11,7 +11,7 @@ const code = `<div>
 export default {
   code,
   goal: [false, true, false, false, false, true, false, false, false],
-  hint1: 'You can target by attributes if<br/>you add them in sqare brackets',
+  hint1: 'You can target by attributes if<br/>you add them in square brackets',
   hint2: 'https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors',
   solution: 'span[data-item]',
 }


### PR DESCRIPTION
"Square" was wrongly written "sqare"